### PR TITLE
Find binary with shutil for simplicity.

### DIFF
--- a/rplugin/python3/deoplete/sources/swift.py
+++ b/rplugin/python3/deoplete/sources/swift.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shutil
 import subprocess
 import sys
 import json
@@ -127,18 +128,8 @@ class Source(Base):
             return self.find_binary_path('sourcekitten')
 
     def find_binary_path(self, cmd):
-        def is_exec(fpath):
-            return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+        path = shutil.which(cmd, mode=os.X_OK)
+        if path is None:
+            return error(self.vim, cmd + ' binary not found')
 
-        fpath, fname = os.path.split(cmd)
-        if fpath:
-            if is_exec(cmd):
-                return cmd
-        else:
-            for path in os.environ["PATH"].split(os.pathsep):
-                path = path.strip('"')
-                binary = os.path.join(path, cmd)
-                if is_exec(binary):
-                    return binary
-        return error(self.vim, cmd + ' binary not found')
-
+        return path

--- a/rplugin/python3/deoplete/sources/swift.py
+++ b/rplugin/python3/deoplete/sources/swift.py
@@ -119,12 +119,9 @@ class Source(Base):
         return ' '.join(param_list)
 
     def source_kitten_binary(self):
-        try:
-            if os.access(self._source_kitten_binary, mode=os.X_OK):
-                return self._source_kitten_binary
-            else:
-                raise
-        except Exception:
+        if os.access(self._source_kitten_binary, mode=os.X_OK):
+            return self._source_kitten_binary
+        else:
             return self.find_binary_path('sourcekitten')
 
     def find_binary_path(self, cmd):

--- a/rplugin/python3/deoplete/sources/swift.py
+++ b/rplugin/python3/deoplete/sources/swift.py
@@ -120,7 +120,7 @@ class Source(Base):
 
     def source_kitten_binary(self):
         try:
-            if os.path.isfile(self._source_kitten_binary):
+            if os.access(self._source_kitten_binary, mode=os.X_OK):
                 return self._source_kitten_binary
             else:
                 raise


### PR DESCRIPTION
This pull-request improve simplicity of code:
- Simplify `find_binary_path` by using [`shutil.which`](https://docs.python.org/3.5/library/shutil.html#shutil.which). **This requires Python >= 3.3.**
- Remove `try~exception` in `source_kitten_binary` (I think it is neeldess).
- Check the executability of the command located at `_source_kitten_binary`.
