### PR TITLE
Choose a completer such as SourceKitten based on the given path.

### DIFF
--- a/rplugin/python3/deoplete/sources/swift.py
+++ b/rplugin/python3/deoplete/sources/swift.py
@@ -95,12 +95,10 @@ class SourceKitten(object):
         ]
 
         stdout_data, stderr_data = SourceKitten.__execute(command_complete)
-        result = stdout_data.decode()
-
         if stderr_data != b'':
             raise Exception((command_complete, stderr_data.decode()))
 
-        return json.loads(result)
+        return json.loads(stdout_data.decode())
 
     @staticmethod
     def __execute(command):

--- a/rplugin/python3/deoplete/sources/swift.py
+++ b/rplugin/python3/deoplete/sources/swift.py
@@ -36,16 +36,15 @@ class Source(Base):
             charpos2bytepos(self.vim, context['input'][: column], column) - 1
         source = '\n'.join(buf).encode()
 
-        fp = tempfile.NamedTemporaryFile(delete=False, suffix=".swift")
-        fp.write(source)
-        fp.flush()
-        fp.close()
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".swift") as fp:
+            fp.write(source)
+            path = fp.name
 
-        client = self.__decide_completer(fp.name)
+        client = self.__decide_completer(path)
         try:
-            results = client.complete(fp.name, offset)
+            results = client.complete(path, offset)
         finally:
-            os.remove(fp.name)
+            os.remove(path)
 
         return self.identifiers_from_result(results)
 

--- a/rplugin/python3/deoplete/sources/swift.py
+++ b/rplugin/python3/deoplete/sources/swift.py
@@ -87,7 +87,7 @@ class SourceKitten(object):
 
         stdout_data, stderr_data = SourceKitten.__execute(command_complete)
         if stderr_data != b'':
-            raise Exception((command_complete, stderr_data.decode()))
+            raise SourceKittenCompletionFailed(path, offset, stderr.decode())
 
         return json.loads(stdout_data.decode())
 
@@ -112,6 +112,25 @@ class SourceKitten(object):
             raise SourceKittenNotFound(default)
 
         return default
+
+
+class SourceKittenCompletionFailed(Exception):
+    def __init__(self, path, offset, error):
+        self.__path = path
+        self.__offset = offset
+        self.__error = error
+
+    @property
+    def path(self):
+        return self.__path
+
+    @property
+    def offset(self):
+        return self.__offset
+
+    @property
+    def error(self):
+        return self.__error
 
 
 class SourceKittenNotFound(Exception):

--- a/rplugin/python3/deoplete/sources/swift.py
+++ b/rplugin/python3/deoplete/sources/swift.py
@@ -45,15 +45,15 @@ class Source(Base):
             fp.write(source)
             path = fp.name
 
-        client = self.__decide_completer(path)
+        completer = self.__choose_completer(path)
         try:
-            results = client.complete(path, offset)
+            results = completer.complete(path, offset)
         finally:
             os.remove(path)
 
         return self.identifiers_from_result(results)
 
-    def __decide_completer(self, path):
+    def __choose_completer(self, path):
         return self.__source_kitten
 
     def identifiers_from_result(self, result):


### PR DESCRIPTION
This pull-request for preparation of [SourceKittenDaemon support](https://github.com/landaire/deoplete-swift/pull/4#issuecomment-217974321). The main modifications are as follow:
- Separate codes for invoking `sourcekitten` from the other part.
- Deoplete-swift chooses a completer such as `SourceKitten` class by calling `__choose_completer` with the path of temporary file, which contains the contents of the current buffer.

For SourceKittenDaemon support, `SourceKittenDaemon` counterpart of completer will be required.
It must implement the same interface of `SourceKitten`'s `complete` method.

I assume that `Source` manages pairs of the port number of a daemon instance and the path of `.xcodeproj` and `__choose_completer` generate `SourceKittenDaemon` completer by using them.

This pull-request also contains some refactoring and refinement.Please read the commit comments.
Sorry for conflicting with some part of #4.
