### PR TITLE
Fix charpos2bytepos arg to use &encoding option

### DIFF
--- a/rplugin/python3/deoplete/sources/swift.py
+++ b/rplugin/python3/deoplete/sources/swift.py
@@ -20,6 +20,7 @@ class Source(Base):
         self.filetypes = ['swift']
         self.input_pattern = r'(?:\b[^\W\d]\w*|[\]\)])(?:\.(?:[^\W\d]\w*)?)*\(?'
         self.rank = 500
+        self.encoding = self.vim.options['encoding']
 
         try:
             self.__source_kitten = SourceKitten(
@@ -38,7 +39,7 @@ class Source(Base):
 
         buf = self.vim.current.buffer
         offset = self.vim.call('line2byte', line) + \
-            charpos2bytepos(self.vim, context['input'][: column], column) - 1
+            charpos2bytepos(self.encoding, context['input'][: column], column) - 1
         source = '\n'.join(buf).encode()
 
         with tempfile.NamedTemporaryFile(delete=False, suffix=".swift") as fp:


### PR DESCRIPTION
Fix `charpos2bitepos` arg because that API has been changed.
https://github.com/Shougo/deoplete.nvim/commit/2698f08c78c4862a972dfa10bed4fcd0a0fa9fa2

It will work.
But I'm not familiar Swift language. If Swift language is written only in UTF-8, call `self.vim.options['encoding']` is reduce performance a little.
So, we can hardcoding `utf-8` to the `charpos2bytepos` arg like
https://github.com/zchee/deoplete-go/commit/6074e5468e837b91dad8c4e9591e2f8be70b5d6a

WDYT?
